### PR TITLE
refactor: remove React.forwardRef and replace ElementRef with ComponentRef

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nellavio",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nellavio",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^4.1.6",

--- a/src/components/common/shadcn/alert.tsx
+++ b/src/components/common/shadcn/alert.tsx
@@ -51,18 +51,22 @@ const alertVariants = cva(
  * </Alert>
  * ```
  */
-const Alert = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
+const Alert = ({
+  className,
+  variant,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof alertVariants> & {
+    ref?: React.Ref<HTMLDivElement>;
+  }) => (
   <div
     ref={ref}
     role="alert"
     className={cn(alertVariants({ variant }), className)}
     {...props}
   />
-));
-Alert.displayName = "Alert";
+);
 
 /**
  * Title heading for the alert notification.
@@ -79,17 +83,19 @@ Alert.displayName = "Alert";
  * <AlertTitle className="text-lg">Important Notice</AlertTitle>
  * ```
  */
-const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+const AlertTitle = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement> & {
+  ref?: React.Ref<HTMLParagraphElement>;
+}) => (
   <h5
     ref={ref}
     className={cn("mb-1 font-medium leading-none tracking-tight", className)}
     {...props}
   />
-));
-AlertTitle.displayName = "AlertTitle";
+);
 
 /**
  * Description text content for the alert notification.
@@ -108,16 +114,18 @@ AlertTitle.displayName = "AlertTitle";
  * </AlertDescription>
  * ```
  */
-const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
+const AlertDescription = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement> & {
+  ref?: React.Ref<HTMLParagraphElement>;
+}) => (
   <div
     ref={ref}
     className={cn("text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />
-));
-AlertDescription.displayName = "AlertDescription";
+);
 
 export { Alert, AlertDescription, AlertTitle };

--- a/src/components/common/shadcn/avatar.tsx
+++ b/src/components/common/shadcn/avatar.tsx
@@ -22,10 +22,13 @@ import { cn } from "@/utils/classNames";
  * </Avatar>
  * ```
  */
-const Avatar = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
->(({ className, ...props }, ref) => (
+const Avatar = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> & {
+  ref?: React.Ref<React.ComponentRef<typeof AvatarPrimitive.Root>>;
+}) => (
   <AvatarPrimitive.Root
     ref={ref}
     className={cn(
@@ -34,8 +37,7 @@ const Avatar = React.forwardRef<
     )}
     {...props}
   />
-));
-Avatar.displayName = AvatarPrimitive.Root.displayName;
+);
 
 /**
  * Avatar image component that displays the user's profile picture.
@@ -58,17 +60,19 @@ Avatar.displayName = AvatarPrimitive.Root.displayName;
  * />
  * ```
  */
-const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
+const AvatarImage = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image> & {
+  ref?: React.Ref<React.ComponentRef<typeof AvatarPrimitive.Image>>;
+}) => (
   <AvatarPrimitive.Image
     ref={ref}
     className={cn("aspect-square h-full w-full", className)}
     {...props}
   />
-));
-AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+);
 
 /**
  * Fallback content displayed when avatar image fails to load or is unavailable.
@@ -88,10 +92,13 @@ AvatarImage.displayName = AvatarPrimitive.Image.displayName;
  * </AvatarFallback>
  * ```
  */
-const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Fallback>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
->(({ className, ...props }, ref) => (
+const AvatarFallback = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback> & {
+  ref?: React.Ref<React.ComponentRef<typeof AvatarPrimitive.Fallback>>;
+}) => (
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
@@ -100,7 +107,6 @@ const AvatarFallback = React.forwardRef<
     )}
     {...props}
   />
-));
-AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+);
 
 export { Avatar, AvatarFallback, AvatarImage };

--- a/src/components/common/shadcn/breadcrumb.tsx
+++ b/src/components/common/shadcn/breadcrumb.tsx
@@ -15,13 +15,13 @@ import { cn } from "@/utils/classNames";
  * @param {React.ReactNode} [separator] - Custom separator element between items
  * @param {React.Ref} ref - Forwarded ref to the nav element
  */
-const Breadcrumb = React.forwardRef<
-  HTMLElement,
-  React.ComponentPropsWithoutRef<"nav"> & {
-    separator?: React.ReactNode;
-  }
->(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
-Breadcrumb.displayName = "Breadcrumb";
+const Breadcrumb = ({
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<"nav"> & {
+  separator?: React.ReactNode;
+  ref?: React.Ref<HTMLElement>;
+}) => <nav ref={ref} aria-label="breadcrumb" {...props} />;
 
 /**
  * Ordered list container for breadcrumb items.
@@ -32,10 +32,13 @@ Breadcrumb.displayName = "Breadcrumb";
  * @param {React.ReactNode} children - Breadcrumb items and separators
  * @param {React.Ref} ref - Forwarded ref to the ol element
  */
-const BreadcrumbList = React.forwardRef<
-  HTMLOListElement,
-  React.ComponentPropsWithoutRef<"ol">
->(({ className, ...props }, ref) => (
+const BreadcrumbList = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<"ol"> & {
+  ref?: React.Ref<HTMLOListElement>;
+}) => (
   <ol
     ref={ref}
     className={cn(
@@ -44,8 +47,7 @@ const BreadcrumbList = React.forwardRef<
     )}
     {...props}
   />
-));
-BreadcrumbList.displayName = "BreadcrumbList";
+);
 
 /**
  * Individual breadcrumb item wrapper.
@@ -63,17 +65,19 @@ BreadcrumbList.displayName = "BreadcrumbList";
  * </BreadcrumbItem>
  * ```
  */
-const BreadcrumbItem = React.forwardRef<
-  HTMLLIElement,
-  React.ComponentPropsWithoutRef<"li">
->(({ className, ...props }, ref) => (
+const BreadcrumbItem = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<"li"> & {
+  ref?: React.Ref<HTMLLIElement>;
+}) => (
   <li
     ref={ref}
     className={cn("inline-flex items-center gap-1.5", className)}
     {...props}
   />
-));
-BreadcrumbItem.displayName = "BreadcrumbItem";
+);
 
 /**
  * Clickable link for navigating between breadcrumb levels.
@@ -94,13 +98,17 @@ BreadcrumbItem.displayName = "BreadcrumbItem";
  * </BreadcrumbLink>
  * ```
  */
-const BreadcrumbLink = React.forwardRef<
-  HTMLAnchorElement,
-  React.ComponentPropsWithoutRef<"a"> & {
-    asChild?: boolean;
-    disabledLink?: boolean;
-  }
->(({ asChild, disabledLink, className, ...props }, ref) => {
+const BreadcrumbLink = ({
+  asChild,
+  disabledLink,
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<"a"> & {
+  asChild?: boolean;
+  disabledLink?: boolean;
+  ref?: React.Ref<HTMLAnchorElement>;
+}) => {
   const Comp = disabledLink ? "span" : asChild ? Slot : "a";
 
   return (
@@ -114,8 +122,7 @@ const BreadcrumbLink = React.forwardRef<
       {...props}
     />
   );
-});
-BreadcrumbLink.displayName = "BreadcrumbLink";
+};
 
 /**
  * Current page indicator (non-clickable).
@@ -134,10 +141,13 @@ BreadcrumbLink.displayName = "BreadcrumbLink";
  * </BreadcrumbItem>
  * ```
  */
-const BreadcrumbPage = React.forwardRef<
-  HTMLSpanElement,
-  React.ComponentPropsWithoutRef<"span">
->(({ className, ...props }, ref) => (
+const BreadcrumbPage = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<"span"> & {
+  ref?: React.Ref<HTMLSpanElement>;
+}) => (
   <span
     ref={ref}
     role="link"
@@ -146,8 +156,7 @@ const BreadcrumbPage = React.forwardRef<
     className={cn("font-normal text-primaryText", className)}
     {...props}
   />
-));
-BreadcrumbPage.displayName = "BreadcrumbPage";
+);
 
 /**
  * Visual separator between breadcrumb items.

--- a/src/components/common/shadcn/button.tsx
+++ b/src/components/common/shadcn/button.tsx
@@ -71,50 +71,45 @@ export interface ButtonProps
  * <Button icon={<PhoneIcon />}>Call</Button>
  * ```
  */
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      className,
-      variant,
-      size,
-      asChild = false,
-      loading = false,
-      icon,
-      children,
-      disabled,
-      ...props
-    },
-    ref,
-  ) => {
-    const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        tabIndex={0}
-        {...props}
-        disabled={disabled || loading}
-        aria-busy={loading || undefined}
-      >
-        {asChild ? (
-          children
-        ) : loading ? (
-          <>
-            <div className="flex items-center justify-center">
-              <SpinnerIcon width={36} height={36} />
-            </div>
-            <span className="sr-only">{children}</span>
-          </>
-        ) : (
-          <>
-            {icon && <div className="mr-2">{icon}</div>}
-            {children}
-          </>
-        )}
-      </Comp>
-    );
-  },
-);
-Button.displayName = "Button";
+const Button = ({
+  className,
+  variant,
+  size,
+  asChild = false,
+  loading = false,
+  icon,
+  children,
+  disabled,
+  ref,
+  ...props
+}: ButtonProps & { ref?: React.Ref<HTMLButtonElement> }) => {
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      tabIndex={0}
+      {...props}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+    >
+      {asChild ? (
+        children
+      ) : loading ? (
+        <>
+          <div className="flex items-center justify-center">
+            <SpinnerIcon width={36} height={36} />
+          </div>
+          <span className="sr-only">{children}</span>
+        </>
+      ) : (
+        <>
+          {icon && <div className="mr-2">{icon}</div>}
+          {children}
+        </>
+      )}
+    </Comp>
+  );
+};
 
 export { Button, buttonVariants };

--- a/src/components/common/shadcn/checkbox.tsx
+++ b/src/components/common/shadcn/checkbox.tsx
@@ -24,10 +24,14 @@ import { cn } from "@/utils/classNames";
  * <Label htmlFor="terms">Accept terms</Label>
  * ```
  */
-const Checkbox = React.forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, onKeyDown, ...props }, ref) => (
+const Checkbox = ({
+  className,
+  onKeyDown,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> & {
+  ref?: React.Ref<React.ComponentRef<typeof CheckboxPrimitive.Root>>;
+}) => (
   <CheckboxPrimitive.Root
     ref={ref}
     tabIndex={0}
@@ -55,7 +59,6 @@ const Checkbox = React.forwardRef<
       <Check className="h-4.5 w-4.5" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
-));
-Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+);
 
 export { Checkbox };

--- a/src/components/common/shadcn/command.tsx
+++ b/src/components/common/shadcn/command.tsx
@@ -15,10 +15,13 @@ import { Dialog, DialogContent } from "./dialog";
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the command element
  */
-const Command = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
->(({ className, ...props }, ref) => (
+const Command = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive>>;
+}) => (
   <CommandPrimitive
     ref={ref}
     className={cn(
@@ -27,8 +30,7 @@ const Command = React.forwardRef<
     )}
     {...props}
   />
-));
-Command.displayName = CommandPrimitive.displayName;
+);
 
 interface CommandDialogProps extends DialogProps {}
 
@@ -71,10 +73,13 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the input element
  */
-const CommandInput = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
+const CommandInput = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Input>>;
+}) => (
   <div
     className="flex items-center border-b border-inputBorder px-3"
     cmdk-input-wrapper=""
@@ -89,9 +94,7 @@ const CommandInput = React.forwardRef<
       {...props}
     />
   </div>
-));
-
-CommandInput.displayName = CommandPrimitive.Input.displayName;
+);
 
 /**
  * Scrollable list container for command items.
@@ -100,18 +103,19 @@ CommandInput.displayName = CommandPrimitive.Input.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the list element
  */
-const CommandList = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
+const CommandList = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.List> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.List>>;
+}) => (
   <CommandPrimitive.List
     ref={ref}
     className={cn("max-h-75 overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
-));
-
-CommandList.displayName = CommandPrimitive.List.displayName;
+);
 
 /**
  * Empty state message displayed when no items match the search.
@@ -119,18 +123,18 @@ CommandList.displayName = CommandPrimitive.List.displayName;
  * @component
  * @param {React.Ref} ref - Forwarded ref to the empty element
  */
-const CommandEmpty = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Empty>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
+const CommandEmpty = ({
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Empty>>;
+}) => (
   <CommandPrimitive.Empty
     ref={ref}
     className="py-6 text-center text-sm"
     {...props}
   />
-));
-
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+);
 
 /**
  * Group container for related command items with optional heading.
@@ -139,10 +143,13 @@ CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the group element
  */
-const CommandGroup = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Group>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
+const CommandGroup = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Group>>;
+}) => (
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
@@ -151,9 +158,7 @@ const CommandGroup = React.forwardRef<
     )}
     {...props}
   />
-));
-
-CommandGroup.displayName = CommandPrimitive.Group.displayName;
+);
 
 /**
  * Visual separator between command groups.
@@ -162,17 +167,19 @@ CommandGroup.displayName = CommandPrimitive.Group.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the separator element
  */
-const CommandSeparator = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
+const CommandSeparator = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Separator>>;
+}) => (
   <CommandPrimitive.Separator
     ref={ref}
     className={cn("-mx-1 h-px bg-inputBorder", className)}
     {...props}
   />
-));
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
+);
 
 /**
  * Individual selectable item in the command menu.
@@ -182,10 +189,13 @@ CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the item element
  */
-const CommandItem = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
+const CommandItem = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Item>>;
+}) => (
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
@@ -194,9 +204,7 @@ const CommandItem = React.forwardRef<
     )}
     {...props}
   />
-));
-
-CommandItem.displayName = CommandPrimitive.Item.displayName;
+);
 
 /**
  * Keyboard shortcut indicator displayed at the right edge of command items.

--- a/src/components/common/shadcn/dialog.tsx
+++ b/src/components/common/shadcn/dialog.tsx
@@ -52,10 +52,13 @@ const DialogClose = DialogPrimitive.Close;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the overlay element
  */
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+const DialogOverlay = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Overlay>>;
+}) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
@@ -64,8 +67,7 @@ const DialogOverlay = React.forwardRef<
     )}
     {...props}
   />
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+);
 
 /**
  * Main dialog content container with animations and close button.
@@ -86,10 +88,15 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
  * </DialogContent>
  * ```
  */
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, onOpenAutoFocus, ...props }, ref) => {
+const DialogContent = ({
+  className,
+  children,
+  onOpenAutoFocus,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Content>>;
+}) => {
   const localRef = React.useRef<HTMLDivElement>(null);
 
   const handleOpenAutoFocus = (e: Event) => {
@@ -107,8 +114,12 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={(node: HTMLDivElement | null) => {
           localRef.current = node;
-          if (typeof ref === "function") ref(node);
-          else if (ref) ref.current = node;
+          if (typeof ref === "function") {
+            ref(node);
+          } else if (ref && "current" in ref) {
+            (ref as React.MutableRefObject<HTMLDivElement | null>).current =
+              node;
+          }
         }}
         tabIndex={-1}
         className={cn(
@@ -129,8 +140,7 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Content>
     </DialogPortal>
   );
-});
-DialogContent.displayName = DialogPrimitive.Content.displayName;
+};
 
 /**
  * Header section for dialog title and description.
@@ -186,10 +196,13 @@ DialogFooter.displayName = "DialogFooter";
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the title element
  */
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
+const DialogTitle = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Title>>;
+}) => (
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
@@ -198,8 +211,7 @@ const DialogTitle = React.forwardRef<
     )}
     {...props}
   />
-));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
+);
 
 /**
  * Descriptive text providing context for the dialog.
@@ -208,17 +220,19 @@ DialogTitle.displayName = DialogPrimitive.Title.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the description element
  */
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
+const DialogDescription = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Description>>;
+}) => (
   <DialogPrimitive.Description
     ref={ref}
     className={cn("text-base text-primaryText", className)}
     {...props}
   />
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
+);
 
 export {
   Dialog,

--- a/src/components/common/shadcn/dropdown-menu.tsx
+++ b/src/components/common/shadcn/dropdown-menu.tsx
@@ -80,12 +80,16 @@ const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
  * </DropdownMenuSub>
  * ```
  */
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
+const DropdownMenuSubTrigger = ({
+  className,
+  inset,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>>;
+}) => (
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
@@ -98,9 +102,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {children}
     <ChevronRight className="ml-auto" />
   </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName =
-  DropdownMenuPrimitive.SubTrigger.displayName;
+);
 
 /**
  * Content container for nested submenus with animations.
@@ -110,10 +112,13 @@ DropdownMenuSubTrigger.displayName =
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the content element
  */
-const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+const DropdownMenuSubContent = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> & {
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>>;
+}) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
@@ -122,9 +127,7 @@ const DropdownMenuSubContent = React.forwardRef<
     )}
     {...props}
   />
-));
-DropdownMenuSubContent.displayName =
-  DropdownMenuPrimitive.SubContent.displayName;
+);
 
 /**
  * Main content container for the dropdown menu.
@@ -143,46 +146,46 @@ DropdownMenuSubContent.displayName =
  * </DropdownMenuContent>
  * ```
  */
-const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(
-  (
-    { className, sideOffset = 4, loop = true, onCloseAutoFocus, ...props },
-    ref,
-  ) => {
-    const closedWithPointerRef = React.useRef(false);
+const DropdownMenuContent = ({
+  className,
+  sideOffset = 4,
+  loop = true,
+  onCloseAutoFocus,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.Content>>;
+}) => {
+  const closedWithPointerRef = React.useRef(false);
 
-    return (
-      <DropdownMenuPrimitive.Portal>
-        <DropdownMenuPrimitive.Content
-          ref={ref}
-          sideOffset={sideOffset}
-          loop={loop}
-          className={cn(
-            "z-50 min-w-32 overflow-hidden rounded-md border border-inputBorder bg-dropdownBg p-1 text-primaryText shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            className,
-          )}
-          onPointerDown={() => {
-            closedWithPointerRef.current = true;
-          }}
-          onPointerDownOutside={() => {
-            closedWithPointerRef.current = true;
-          }}
-          onCloseAutoFocus={(e) => {
-            if (closedWithPointerRef.current) {
-              e.preventDefault();
-              closedWithPointerRef.current = false;
-            }
-            onCloseAutoFocus?.(e);
-          }}
-          {...props}
-        />
-      </DropdownMenuPrimitive.Portal>
-    );
-  },
-);
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        loop={loop}
+        className={cn(
+          "z-50 min-w-32 overflow-hidden rounded-md border border-inputBorder bg-dropdownBg p-1 text-primaryText shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        onPointerDown={() => {
+          closedWithPointerRef.current = true;
+        }}
+        onPointerDownOutside={() => {
+          closedWithPointerRef.current = true;
+        }}
+        onCloseAutoFocus={(e) => {
+          if (closedWithPointerRef.current) {
+            e.preventDefault();
+            closedWithPointerRef.current = false;
+          }
+          onCloseAutoFocus?.(e);
+        }}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+};
 
 /**
  * Interactive menu item that triggers an action when selected.
@@ -201,12 +204,15 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
  * </DropdownMenuItem>
  * ```
  */
-const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
+const DropdownMenuItem = ({
+  className,
+  inset,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.Item>>;
+}) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
@@ -216,8 +222,7 @@ const DropdownMenuItem = React.forwardRef<
     )}
     {...props}
   />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+);
 
 /**
  * Menu item with checkbox functionality for toggling options.
@@ -235,10 +240,17 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
  * </DropdownMenuCheckboxItem>
  * ```
  */
-const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
+const DropdownMenuCheckboxItem = ({
+  className,
+  children,
+  checked,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  ref?: React.Ref<
+    React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>
+  >;
+}) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
@@ -255,9 +267,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.CheckboxItem>
-));
-DropdownMenuCheckboxItem.displayName =
-  DropdownMenuPrimitive.CheckboxItem.displayName;
+);
 
 /**
  * Menu item for radio group selection with single choice behavior.
@@ -275,10 +285,14 @@ DropdownMenuCheckboxItem.displayName =
  * </DropdownMenuRadioGroup>
  * ```
  */
-const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
+const DropdownMenuRadioItem = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem> & {
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>>;
+}) => (
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
@@ -294,8 +308,7 @@ const DropdownMenuRadioItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.RadioItem>
-));
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+);
 
 /**
  * Non-interactive label for grouping or describing menu items.
@@ -313,12 +326,15 @@ DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
  * <DropdownMenuItem>Settings</DropdownMenuItem>
  * ```
  */
-const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
+const DropdownMenuLabel = ({
+  className,
+  inset,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.Label>>;
+}) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
@@ -328,8 +344,7 @@ const DropdownMenuLabel = React.forwardRef<
     )}
     {...props}
   />
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+);
 
 /**
  * Visual divider line between menu items or groups.
@@ -338,17 +353,19 @@ DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the separator element
  */
-const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
+const DropdownMenuSeparator = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & {
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.Separator>>;
+}) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
     className={cn("-mx-1 my-1 h-px bg-mainBorder", className)}
     {...props}
   />
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+);
 
 /**
  * Keyboard shortcut hint displayed alongside menu items.

--- a/src/components/common/shadcn/form.tsx
+++ b/src/components/common/shadcn/form.tsx
@@ -148,10 +148,13 @@ const FormItemContext = React.createContext<FormItemContextValue>(
  * </FormItem>
  * ```
  */
-const FormItem = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
+const FormItem = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.Ref<HTMLDivElement>;
+}) => {
   const id = React.useId();
 
   return (
@@ -159,8 +162,7 @@ const FormItem = React.forwardRef<
       <div ref={ref} className={cn("space-y-2", className)} {...props} />
     </FormItemContext.Provider>
   );
-});
-FormItem.displayName = "FormItem";
+};
 
 /**
  * Label component for form fields with error state styling.
@@ -175,10 +177,13 @@ FormItem.displayName = "FormItem";
  * <FormLabel>Email Address</FormLabel>
  * ```
  */
-const FormLabel = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => {
+const FormLabel = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & {
+  ref?: React.Ref<React.ComponentRef<typeof LabelPrimitive.Root>>;
+}) => {
   const { error, formItemId } = useFormField();
 
   return (
@@ -189,8 +194,7 @@ const FormLabel = React.forwardRef<
       {...props}
     />
   );
-});
-FormLabel.displayName = "FormLabel";
+};
 
 /**
  * Wrapper for form control elements (inputs, selects, etc.).
@@ -206,10 +210,12 @@ FormLabel.displayName = "FormLabel";
  * </FormControl>
  * ```
  */
-const FormControl = React.forwardRef<
-  React.ElementRef<typeof Slot>,
-  React.ComponentPropsWithoutRef<typeof Slot>
->(({ ...props }, ref) => {
+const FormControl = ({
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof Slot> & {
+  ref?: React.Ref<React.ComponentRef<typeof Slot>>;
+}) => {
   const { error, formItemId, formDescriptionId, formMessageId } =
     useFormField();
 
@@ -226,8 +232,7 @@ const FormControl = React.forwardRef<
       {...props}
     />
   );
-});
-FormControl.displayName = "FormControl";
+};
 
 /**
  * Descriptive text for form fields providing additional context or instructions.
@@ -244,10 +249,13 @@ FormControl.displayName = "FormControl";
  * </FormDescription>
  * ```
  */
-const FormDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => {
+const FormDescription = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement> & {
+  ref?: React.Ref<HTMLParagraphElement>;
+}) => {
   const { formDescriptionId } = useFormField();
 
   return (
@@ -258,8 +266,7 @@ const FormDescription = React.forwardRef<
       {...props}
     />
   );
-});
-FormDescription.displayName = "FormDescription";
+};
 
 /**
  * Displays validation error messages for form fields.
@@ -276,10 +283,14 @@ FormDescription.displayName = "FormDescription";
  * <FormMessage />
  * ```
  */
-const FormMessage = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, children, ...props }, ref) => {
+const FormMessage = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement> & {
+  ref?: React.Ref<HTMLParagraphElement>;
+}) => {
   const { error, formMessageId } = useFormField();
   const body = error ? String(error?.message) : children;
 
@@ -295,8 +306,7 @@ const FormMessage = React.forwardRef<
       {...props}
     />
   );
-});
-FormMessage.displayName = "FormMessage";
+};
 
 export {
   Form,

--- a/src/components/common/shadcn/input-group.tsx
+++ b/src/components/common/shadcn/input-group.tsx
@@ -34,10 +34,14 @@ const InputGroupContext = React.createContext<InputGroupContextValue>({
  * </InputGroup>
  * ```
  */
-const InputGroup = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, children, ...props }, ref) => {
+const InputGroup = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.Ref<HTMLDivElement>;
+}) => {
   const childrenArray = React.Children.toArray(children);
 
   const checkAddonAlignment = (
@@ -86,8 +90,7 @@ const InputGroup = React.forwardRef<
       </div>
     </InputGroupContext.Provider>
   );
-});
-InputGroup.displayName = "InputGroup";
+};
 
 /**
  * Style variants configuration for the InputGroupAddon component.
@@ -131,17 +134,20 @@ interface InputGroupAddonProps
  * </InputGroupAddon>
  * ```
  */
-const InputGroupAddon = React.forwardRef<HTMLDivElement, InputGroupAddonProps>(
-  ({ className, align, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className={cn(inputGroupAddonVariants({ align }), className)}
-        {...props}
-      />
-    );
-  },
-);
+const InputGroupAddon = ({
+  className,
+  align,
+  ref,
+  ...props
+}: InputGroupAddonProps & { ref?: React.Ref<HTMLDivElement> }) => {
+  return (
+    <div
+      ref={ref}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      {...props}
+    />
+  );
+};
 InputGroupAddon.displayName = "InputGroupAddon";
 
 /**
@@ -192,31 +198,29 @@ interface InputGroupButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEle
  * </InputGroupAddon>
  * ```
  */
-const InputGroupButton = React.forwardRef<
-  HTMLButtonElement,
-  InputGroupButtonProps
->(
-  (
-    { className, variant = "ghost", size = "xs", type = "button", ...props },
-    ref,
-  ) => {
-    return (
-      <button
-        ref={ref}
-        type={type}
-        tabIndex={0}
-        className={cn(
-          buttonVariants({ variant, size: "default" }),
-          inputGroupButtonVariants({ size }),
-          "pointer-events-auto text-grayIcon stroke-grayIcon",
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
-InputGroupButton.displayName = "InputGroupButton";
+const InputGroupButton = ({
+  className,
+  variant = "ghost",
+  size = "xs",
+  type = "button",
+  ref,
+  ...props
+}: InputGroupButtonProps & { ref?: React.Ref<HTMLButtonElement> }) => {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      tabIndex={0}
+      className={cn(
+        buttonVariants({ variant, size: "default" }),
+        inputGroupButtonVariants({ size }),
+        "pointer-events-auto text-grayIcon stroke-grayIcon",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
 
 /**
  * Text display component for non-interactive content within InputGroupAddon.
@@ -233,10 +237,13 @@ InputGroupButton.displayName = "InputGroupButton";
  * </InputGroupAddon>
  * ```
  */
-const InputGroupText = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
+const InputGroupText = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.Ref<HTMLDivElement>;
+}) => {
   return (
     <div
       ref={ref}
@@ -247,8 +254,7 @@ const InputGroupText = React.forwardRef<
       {...props}
     />
   );
-});
-InputGroupText.displayName = "InputGroupText";
+};
 
 /**
  * Style variants configuration for the InputGroupInput component.
@@ -297,10 +303,14 @@ interface InputGroupInputProps
  * </InputGroup>
  * ```
  */
-const InputGroupInput = React.forwardRef<
-  HTMLInputElement,
-  InputGroupInputProps
->(({ className, type, variant, fixedHeight, ...props }, ref) => {
+const InputGroupInput = ({
+  className,
+  type,
+  variant,
+  fixedHeight,
+  ref,
+  ...props
+}: InputGroupInputProps & { ref?: React.Ref<HTMLInputElement> }) => {
   const { hasLeftAddon, hasRightAddon } = React.useContext(InputGroupContext);
 
   return (
@@ -318,8 +328,7 @@ const InputGroupInput = React.forwardRef<
       {...props}
     />
   );
-});
-InputGroupInput.displayName = "InputGroupInput";
+};
 
 interface InputGroupTextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
@@ -341,10 +350,11 @@ interface InputGroupTextareaProps extends React.TextareaHTMLAttributes<HTMLTextA
  * </InputGroup>
  * ```
  */
-const InputGroupTextarea = React.forwardRef<
-  HTMLTextAreaElement,
-  InputGroupTextareaProps
->(({ className, ...props }, ref) => {
+const InputGroupTextarea = ({
+  className,
+  ref,
+  ...props
+}: InputGroupTextareaProps & { ref?: React.Ref<HTMLTextAreaElement> }) => {
   return (
     <textarea
       className={cn(
@@ -356,8 +366,7 @@ const InputGroupTextarea = React.forwardRef<
       {...props}
     />
   );
-});
-InputGroupTextarea.displayName = "InputGroupTextarea";
+};
 
 export {
   InputGroup,

--- a/src/components/common/shadcn/input.tsx
+++ b/src/components/common/shadcn/input.tsx
@@ -25,21 +25,23 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
  * />
  * ```
  */
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-inputBorder bg-inputBg px-3 py-2 text-base md:text-sm transition file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-placeholderText hover:bg-inputBgHover hover:border-inputBorderHover focus:border-inputBorderFocus focus-visible:!outline-none disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
-Input.displayName = "Input";
+const Input = ({
+  className,
+  type,
+  ref,
+  ...props
+}: InputProps & { ref?: React.Ref<HTMLInputElement> }) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-inputBorder bg-inputBg px-3 py-2 text-base md:text-sm transition file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-placeholderText hover:bg-inputBgHover hover:border-inputBorderHover focus:border-inputBorderFocus focus-visible:!outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+};
 
 export { Input };

--- a/src/components/common/shadcn/label.tsx
+++ b/src/components/common/shadcn/label.tsx
@@ -35,16 +35,19 @@ interface LabelProps
   withPointer?: boolean;
 }
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  LabelProps
->(({ className, withPointer, ...props }, ref) => (
+const Label = ({
+  className,
+  withPointer,
+  ref,
+  ...props
+}: LabelProps & {
+  ref?: React.Ref<React.ComponentRef<typeof LabelPrimitive.Root>>;
+}) => (
   <LabelPrimitive.Root
     ref={ref}
     className={cn(labelVariants(), withPointer && "cursor-pointer", className)}
     {...props}
   />
-));
-Label.displayName = LabelPrimitive.Root.displayName;
+);
 
 export { Label };

--- a/src/components/common/shadcn/popover.tsx
+++ b/src/components/common/shadcn/popover.tsx
@@ -43,45 +43,45 @@ const PopoverTrigger = PopoverPrimitive.Trigger;
  * </PopoverContent>
  * ```
  */
-const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(
-  (
-    { className, align = "center", sideOffset = 4, onCloseAutoFocus, ...props },
-    ref,
-  ) => {
-    const closedWithPointerRef = React.useRef(false);
+const PopoverContent = ({
+  className,
+  align = "center",
+  sideOffset = 4,
+  onCloseAutoFocus,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof PopoverPrimitive.Content>>;
+}) => {
+  const closedWithPointerRef = React.useRef(false);
 
-    return (
-      <PopoverPrimitive.Portal>
-        <PopoverPrimitive.Content
-          ref={ref}
-          align={align}
-          sideOffset={sideOffset}
-          className={cn(
-            "z-50 w-72 rounded-md border border-inputBorder bg-dropdownBg p-4 text-primaryText shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            className,
-          )}
-          onPointerDown={() => {
-            closedWithPointerRef.current = true;
-          }}
-          onPointerDownOutside={() => {
-            closedWithPointerRef.current = true;
-          }}
-          onCloseAutoFocus={(e) => {
-            if (closedWithPointerRef.current) {
-              e.preventDefault();
-              closedWithPointerRef.current = false;
-            }
-            onCloseAutoFocus?.(e);
-          }}
-          {...props}
-        />
-      </PopoverPrimitive.Portal>
-    );
-  },
-);
-PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 rounded-md border border-inputBorder bg-dropdownBg p-4 text-primaryText shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        onPointerDown={() => {
+          closedWithPointerRef.current = true;
+        }}
+        onPointerDownOutside={() => {
+          closedWithPointerRef.current = true;
+        }}
+        onCloseAutoFocus={(e) => {
+          if (closedWithPointerRef.current) {
+            e.preventDefault();
+            closedWithPointerRef.current = false;
+          }
+          onCloseAutoFocus?.(e);
+        }}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+};
 
 export { Popover, PopoverContent, PopoverTrigger };

--- a/src/components/common/shadcn/progress.tsx
+++ b/src/components/common/shadcn/progress.tsx
@@ -26,10 +26,16 @@ interface ProgressProps extends React.ComponentPropsWithoutRef<
  * <Progress value={70} indicatorColor="#00ff00" />
  * ```
  */
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  ProgressProps
->(({ className, value, indicatorColor, label = "Progress", ...props }, ref) => (
+const Progress = ({
+  className,
+  value,
+  indicatorColor,
+  label = "Progress",
+  ref,
+  ...props
+}: ProgressProps & {
+  ref?: React.Ref<React.ComponentRef<typeof ProgressPrimitive.Root>>;
+}) => (
   <ProgressPrimitive.Root
     ref={ref}
     aria-label={label}
@@ -47,7 +53,6 @@ const Progress = React.forwardRef<
       }}
     />
   </ProgressPrimitive.Root>
-));
-Progress.displayName = ProgressPrimitive.Root.displayName;
+);
 
 export { Progress };

--- a/src/components/common/shadcn/radio-group.tsx
+++ b/src/components/common/shadcn/radio-group.tsx
@@ -24,17 +24,19 @@ import { cn } from "@/utils/classNames";
  * </RadioGroup>
  * ```
  */
-const RadioGroup = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => (
+const RadioGroup = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & {
+  ref?: React.Ref<React.ComponentRef<typeof RadioGroupPrimitive.Root>>;
+}) => (
   <RadioGroupPrimitive.Root
     className={cn("grid gap-3", className)}
     {...props}
     ref={ref}
   />
-));
-RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+);
 
 /**
  * Individual radio button item within a RadioGroup.
@@ -50,10 +52,14 @@ RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
  * <RadioGroupItem value="default" id="r1" />
  * ```
  */
-const RadioGroupItem = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
->(({ className, onKeyDown, ...props }, ref) => (
+const RadioGroupItem = ({
+  className,
+  onKeyDown,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> & {
+  ref?: React.Ref<React.ComponentRef<typeof RadioGroupPrimitive.Item>>;
+}) => (
   <RadioGroupPrimitive.Item
     ref={ref}
     tabIndex={0}
@@ -74,7 +80,6 @@ const RadioGroupItem = React.forwardRef<
       <Circle className="absolute top-1/2 left-1/2 h-2.75 w-2.75 -translate-x-1/2 -translate-y-1/2 fill-current text-current" />
     </RadioGroupPrimitive.Indicator>
   </RadioGroupPrimitive.Item>
-));
-RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+);
 
 export { RadioGroup, RadioGroupItem };

--- a/src/components/common/shadcn/select.tsx
+++ b/src/components/common/shadcn/select.tsx
@@ -45,10 +45,14 @@ const SelectValue = SelectPrimitive.Value;
  * @param {React.ReactNode} children - Trigger content (typically SelectValue)
  * @param {React.Ref} ref - Forwarded ref to the trigger element
  */
-const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+const SelectTrigger = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Trigger>>;
+}) => (
   <SelectPrimitive.Trigger
     ref={ref}
     tabIndex={0}
@@ -63,8 +67,7 @@ const SelectTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+);
 
 /**
  * Button to scroll up through select options when content overflows.
@@ -73,10 +76,13 @@ SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the button element
  */
-const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
+const SelectScrollUpButton = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>>;
+}) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={cn(
@@ -87,8 +93,7 @@ const SelectScrollUpButton = React.forwardRef<
   >
     <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
-));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+);
 
 /**
  * Button to scroll down through select options when content overflows.
@@ -97,10 +102,13 @@ SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the button element
  */
-const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
+const SelectScrollDownButton = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>>;
+}) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={cn(
@@ -111,9 +119,7 @@ const SelectScrollDownButton = React.forwardRef<
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
-));
-SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName;
+);
 
 /**
  * Dropdown content container for select options.
@@ -133,10 +139,15 @@ SelectScrollDownButton.displayName =
  * </SelectContent>
  * ```
  */
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
+const SelectContent = ({
+  className,
+  children,
+  position = "popper",
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Content>>;
+}) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
@@ -162,8 +173,7 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
+);
 
 /**
  * Label for grouping related select options.
@@ -181,10 +191,13 @@ SelectContent.displayName = SelectPrimitive.Content.displayName;
  * </SelectGroup>
  * ```
  */
-const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
+const SelectLabel = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Label>>;
+}) => (
   <SelectPrimitive.Label
     ref={ref}
     className={cn(
@@ -196,8 +209,7 @@ const SelectLabel = React.forwardRef<
     <span className="w-3.5 mr-2 shrink-0" />
     {props.children}
   </SelectPrimitive.Label>
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
+);
 
 /**
  * Individual selectable option item.
@@ -214,10 +226,14 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
  * <SelectItem value="dark">Dark Mode</SelectItem>
  * ```
  */
-const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+const SelectItem = ({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Item>>;
+}) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
@@ -234,8 +250,7 @@ const SelectItem = React.forwardRef<
 
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
+);
 
 /**
  * Visual separator between groups of select options.
@@ -244,17 +259,19 @@ SelectItem.displayName = SelectPrimitive.Item.displayName;
  * @param {string} [className] - Additional CSS classes to apply
  * @param {React.Ref} ref - Forwarded ref to the separator element
  */
-const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
+const SelectSeparator = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Separator>>;
+}) => (
   <SelectPrimitive.Separator
     ref={ref}
     className={cn("-mx-1 my-1 h-px bg-inputBorder", className)}
     {...props}
   />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+);
 
 export {
   Select,

--- a/src/components/common/shadcn/separator.tsx
+++ b/src/components/common/shadcn/separator.tsx
@@ -33,35 +33,29 @@ interface SeparatorProps extends React.ComponentPropsWithoutRef<
   color?: string;
 }
 
-const Separator = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
-  SeparatorProps
->(
-  (
-    {
+const Separator = ({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  color,
+  ref,
+  ...props
+}: SeparatorProps & {
+  ref?: React.Ref<React.ComponentRef<typeof SeparatorPrimitive.Root>>;
+}) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0",
+      !color && "bg-inputBorder",
+      orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
       className,
-      orientation = "horizontal",
-      decorative = true,
-      color,
-      ...props
-    },
-    ref,
-  ) => (
-    <SeparatorPrimitive.Root
-      ref={ref}
-      decorative={decorative}
-      orientation={orientation}
-      className={cn(
-        "shrink-0",
-        !color && "bg-inputBorder",
-        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
-        className,
-      )}
-      style={color ? { backgroundColor: color } : undefined}
-      {...props}
-    />
-  ),
+    )}
+    style={color ? { backgroundColor: color } : undefined}
+    {...props}
+  />
 );
-Separator.displayName = SeparatorPrimitive.Root.displayName;
 
 export { Separator };

--- a/src/components/common/shadcn/slider.tsx
+++ b/src/components/common/shadcn/slider.tsx
@@ -24,10 +24,13 @@ import { cn } from "@/utils/classNames";
  * />
  * ```
  */
-const Slider = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => {
+const Slider = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  ref?: React.Ref<React.ComponentRef<typeof SliderPrimitive.Root>>;
+}) => {
   const initialValue = Array.isArray(props.defaultValue)
     ? props.defaultValue
     : [props.defaultValue ?? 0];
@@ -59,7 +62,6 @@ const Slider = React.forwardRef<
       ))}
     </SliderPrimitive.Root>
   );
-});
-Slider.displayName = SliderPrimitive.Root.displayName;
+};
 
 export { Slider };

--- a/src/components/common/shadcn/switch.tsx
+++ b/src/components/common/shadcn/switch.tsx
@@ -22,10 +22,13 @@ import { cn } from "@/utils/classNames";
  * />
  * ```
  */
-const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
->(({ className, ...props }, ref) => (
+const Switch = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root> & {
+  ref?: React.Ref<React.ComponentRef<typeof SwitchPrimitive.Root>>;
+}) => (
   <SwitchPrimitive.Root
     tabIndex={0}
     className={cn(
@@ -41,7 +44,6 @@ const Switch = React.forwardRef<
       )}
     />
   </SwitchPrimitive.Root>
-));
-Switch.displayName = SwitchPrimitive.Root.displayName;
+);
 
 export { Switch };

--- a/src/components/common/shadcn/tabs.tsx
+++ b/src/components/common/shadcn/tabs.tsx
@@ -37,12 +37,15 @@ const Tabs = TabsPrimitive.Root;
  * </TabsList>
  * ```
  */
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
-    variant?: "default" | "line";
-  }
->(({ className, variant = "default", ...props }, ref) => (
+const TabsList = ({
+  className,
+  variant = "default",
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+  variant?: "default" | "line";
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.List>>;
+}) => (
   <TabsPrimitive.List
     ref={ref}
     className={cn(
@@ -55,8 +58,7 @@ const TabsList = React.forwardRef<
     )}
     {...props}
   />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+);
 
 /**
  * Individual tab button that activates its corresponding content panel.
@@ -74,12 +76,15 @@ TabsList.displayName = TabsPrimitive.List.displayName;
  * </TabsTrigger>
  * ```
  */
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
-    variant?: "default" | "line";
-  }
->(({ className, variant = "default", ...props }, ref) => (
+const TabsTrigger = ({
+  className,
+  variant = "default",
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
+  variant?: "default" | "line";
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.Trigger>>;
+}) => (
   <TabsPrimitive.Trigger
     ref={ref}
     tabIndex={0}
@@ -93,8 +98,7 @@ const TabsTrigger = React.forwardRef<
     )}
     {...props}
   />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+);
 
 /**
  * Content panel that displays when its corresponding tab trigger is active.
@@ -111,16 +115,18 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
  * </TabsContent>
  * ```
  */
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
+const TabsContent = ({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.Content>>;
+}) => (
   <TabsPrimitive.Content
     ref={ref}
     className={cn("mt-2", className)}
     {...props}
   />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+);
 
 export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/src/components/common/shadcn/textarea.tsx
+++ b/src/components/common/shadcn/textarea.tsx
@@ -28,20 +28,21 @@ export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextArea
  * />
  * ```
  */
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          "flex min-h-20 w-full rounded-md border border-inputBorder bg-inputBg px-3 py-2 text-sm transition placeholder:text-secondaryText hover:border-inputBorderHover disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
-Textarea.displayName = "Textarea";
+const Textarea = ({
+  className,
+  ref,
+  ...props
+}: TextareaProps & { ref?: React.Ref<HTMLTextAreaElement> }) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-20 w-full rounded-md border border-inputBorder bg-inputBg px-3 py-2 text-sm transition placeholder:text-secondaryText hover:border-inputBorderHover disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+};
 
 export { Textarea };

--- a/src/components/common/shadcn/tooltip.tsx
+++ b/src/components/common/shadcn/tooltip.tsx
@@ -63,10 +63,15 @@ const TooltipPortal = TooltipPrimitive.Portal;
  * </TooltipContent>
  * ```
  */
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, align = "start", ...props }, ref) => (
+const TooltipContent = ({
+  className,
+  sideOffset = 4,
+  align = "start",
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof TooltipPrimitive.Content>>;
+}) => (
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
       ref={ref}
@@ -79,8 +84,7 @@ const TooltipContent = React.forwardRef<
       {...props}
     />
   </TooltipPrimitive.Portal>
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+);
 
 export {
   Tooltip,

--- a/src/components/layout/navbar/parts/SearchInput.tsx
+++ b/src/components/layout/navbar/parts/SearchInput.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useEffect, useRef } from "react";
+import type { Ref } from "react";
+import { useEffect, useRef } from "react";
 
 import { SearchIcon } from "@/assets/icons/SearchIcon";
 import {
@@ -16,131 +17,133 @@ interface SearchInputProps {
   close: () => void;
 }
 
-export const SearchInput = forwardRef<HTMLDivElement, SearchInputProps>(
-  ({ isOpen, open, close, closeOthers }, ref) => {
-    const {
-      searchText,
-      filteredSections,
-      searchPlaceholder,
-      noResultsText,
-      highlightedIndex,
-      handleSearchChange,
-      handleInputFocus,
-      handleClick,
-      handleSectionClick,
-      handleKeyDown,
-    } = useSearchInput({
-      closeOthers,
-      open,
-      close,
-      isOpen,
-    });
+export const SearchInput = ({
+  isOpen,
+  open,
+  close,
+  closeOthers,
+  ref,
+}: SearchInputProps & { ref?: Ref<HTMLDivElement> }) => {
+  const {
+    searchText,
+    filteredSections,
+    searchPlaceholder,
+    noResultsText,
+    highlightedIndex,
+    handleSearchChange,
+    handleInputFocus,
+    handleClick,
+    handleSectionClick,
+    handleKeyDown,
+  } = useSearchInput({
+    closeOthers,
+    open,
+    close,
+    isOpen,
+  });
 
-    const inputRef = useRef<HTMLInputElement>(null);
-    const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
-    /** Listens for the "global-focus-search" custom event dispatched by the global hotkey handler. */
-    useEffect(() => {
-      const handleGlobalFocusSearch = () => {
-        if (closeOthers) closeOthers();
-        open();
-        inputRef.current?.focus();
-      };
+  /** Listens for the "global-focus-search" custom event dispatched by the global hotkey handler. */
+  useEffect(() => {
+    const handleGlobalFocusSearch = () => {
+      if (closeOthers) closeOthers();
+      open();
+      inputRef.current?.focus();
+    };
 
-      document.addEventListener("global-focus-search", handleGlobalFocusSearch);
-      return () =>
-        document.removeEventListener(
-          "global-focus-search",
-          handleGlobalFocusSearch,
-        );
-    }, [closeOthers, open]);
+    document.addEventListener("global-focus-search", handleGlobalFocusSearch);
+    return () =>
+      document.removeEventListener(
+        "global-focus-search",
+        handleGlobalFocusSearch,
+      );
+  }, [closeOthers, open]);
 
-    useEffect(() => {
-      if (highlightedIndex >= 0 && itemRefs.current[highlightedIndex]) {
-        itemRefs.current[highlightedIndex]?.scrollIntoView({
-          block: "nearest",
-        });
-      }
-    }, [highlightedIndex]);
+  useEffect(() => {
+    if (highlightedIndex >= 0 && itemRefs.current[highlightedIndex]) {
+      itemRefs.current[highlightedIndex]?.scrollIntoView({
+        block: "nearest",
+      });
+    }
+  }, [highlightedIndex]);
 
-    return (
-      <>
-        <div
-          className="2xl:-ml-[0.05rem] 3xl:ml-[0.05rem] w-68 alternativeScrollbar hidden lg:block"
-          ref={ref}
-        >
-          <div className="relative w-full">
-            <InputGroup className="h-[2.2rem] 1xl:h-10 1xl:translate-y-[0.2rem] 3xl:translate-y-0">
-              <InputGroupInput
-                ref={inputRef}
-                variant="navbarSearch"
-                type="text"
-                placeholder={searchPlaceholder}
-                value={searchText}
-                onChange={handleSearchChange}
-                onFocus={handleInputFocus}
-                onClick={handleClick}
-                onKeyDown={handleKeyDown}
-                role="combobox"
-                aria-expanded={isOpen}
-                aria-haspopup="listbox"
-                aria-controls="search-listbox"
-                aria-activedescendant={
-                  highlightedIndex >= 0
-                    ? `search-option-${highlightedIndex}`
-                    : undefined
-                }
-                autoComplete="off"
-                className="z-30 text-primaryText text-xs 1xl:text-sm placeholder:text-xs placeholder:1xl:text-sm"
-              />
-              <InputGroupAddon>
-                <SearchIcon />
-              </InputGroupAddon>
-            </InputGroup>
-            {isOpen && (
-              <div
-                id="search-listbox"
-                role="listbox"
-                tabIndex={-1}
-                className="absolute top-full left-0 w-[200%] mt-1 bg-dropdownBg border border-inputBorder rounded-md shadow-md z-40 max-h-64 overflow-y-auto"
-              >
-                {filteredSections.length > 0 ? (
-                  filteredSections.map((item, index) => (
-                    <div
-                      key={index}
-                      id={`search-option-${index}`}
-                      role="option"
-                      aria-selected={index === highlightedIndex}
-                      ref={(el) => {
-                        itemRefs.current[index] = el;
-                      }}
-                      onClick={() => handleSectionClick(item)}
-                      className={`flex justify-between items-center px-5 py-4 cursor-pointer border-b border-mainBorder last:border-b-0 ${
-                        index === highlightedIndex
-                          ? "bg-dropdownBgHover"
-                          : "hover:bg-dropdownBgHover"
-                      }`}
-                    >
-                      <span className="text-primaryText font-medium text-sm 1xl:text-md">
-                        {item.translatedSection}
-                      </span>
-                      <div className="bg-outlinedButtonBg text-secondaryText text-xs px-2 py-1 rounded border border-mainBorder">
-                        {item.translatedPage}
-                      </div>
+  return (
+    <>
+      <div
+        className="2xl:-ml-[0.05rem] 3xl:ml-[0.05rem] w-68 alternativeScrollbar hidden lg:block"
+        ref={ref}
+      >
+        <div className="relative w-full">
+          <InputGroup className="h-[2.2rem] 1xl:h-10 1xl:translate-y-[0.2rem] 3xl:translate-y-0">
+            <InputGroupInput
+              ref={inputRef}
+              variant="navbarSearch"
+              type="text"
+              placeholder={searchPlaceholder}
+              value={searchText}
+              onChange={handleSearchChange}
+              onFocus={handleInputFocus}
+              onClick={handleClick}
+              onKeyDown={handleKeyDown}
+              role="combobox"
+              aria-expanded={isOpen}
+              aria-haspopup="listbox"
+              aria-controls="search-listbox"
+              aria-activedescendant={
+                highlightedIndex >= 0
+                  ? `search-option-${highlightedIndex}`
+                  : undefined
+              }
+              autoComplete="off"
+              className="z-30 text-primaryText text-xs 1xl:text-sm placeholder:text-xs placeholder:1xl:text-sm"
+            />
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+          </InputGroup>
+          {isOpen && (
+            <div
+              id="search-listbox"
+              role="listbox"
+              tabIndex={-1}
+              className="absolute top-full left-0 w-[200%] mt-1 bg-dropdownBg border border-inputBorder rounded-md shadow-md z-40 max-h-64 overflow-y-auto"
+            >
+              {filteredSections.length > 0 ? (
+                filteredSections.map((item, index) => (
+                  <div
+                    key={index}
+                    id={`search-option-${index}`}
+                    role="option"
+                    aria-selected={index === highlightedIndex}
+                    ref={(el) => {
+                      itemRefs.current[index] = el;
+                    }}
+                    onClick={() => handleSectionClick(item)}
+                    className={`flex justify-between items-center px-5 py-4 cursor-pointer border-b border-mainBorder last:border-b-0 ${
+                      index === highlightedIndex
+                        ? "bg-dropdownBgHover"
+                        : "hover:bg-dropdownBgHover"
+                    }`}
+                  >
+                    <span className="text-primaryText font-medium text-sm 1xl:text-md">
+                      {item.translatedSection}
+                    </span>
+                    <div className="bg-outlinedButtonBg text-secondaryText text-xs px-2 py-1 rounded border border-mainBorder">
+                      {item.translatedPage}
                     </div>
-                  ))
-                ) : (
-                  <div className="px-5 py-5 text-center text-secondaryText">
-                    {noResultsText}
                   </div>
-                )}
-              </div>
-            )}
-          </div>
+                ))
+              ) : (
+                <div className="px-5 py-5 text-center text-secondaryText">
+                  {noResultsText}
+                </div>
+              )}
+            </div>
+          )}
         </div>
-      </>
-    );
-  },
-);
-
-SearchInput.displayName = "SearchInput";
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
This PR updates our custom Shadcn component primitives to align with React 19 standard patterns:

    1. **Removed `React.forwardRef` wrappers**: Since React 19 passes `ref` as a normal prop, we no longer need the `forwardRef` wrapper functions or
  the manual `.displayName` assignments on components.
    2. **Replaced `React.ElementRef` with `React.ComponentRef`**: React 19 deprecates `ElementRef`. We migrated all instances to `ComponentRef` to
  future-proof the type definitions.

    ### Changes
    - Refactored 23 Shadcn component files under `src/components/common/shadcn/` (including `button`, `input`, `dialog`, `dropdown-menu`, `popover`,
  `select`, etc.).
    - Stripped `forwardRef` wrappers and simplified the component signatures.
    - Updated typing to use `React.ComponentRef` and `ComponentPropsWithoutRef` / `ComponentProps` correctly.
    - Retained exact component behavior and ensured that Radix UI's `asChild` composition (e.g., button triggers wrapping other components) continues to
  position and mount correctly.

    ### Verification
    - Ran `npm run type-check` (no TypeScript compilation issues).
    - Ran `npm run lint` (formatting and imports are clean).
    - Ran `npm run test` (all 240 unit tests pass).
    - Verified production Next.js compilation works successfully via `npm run build`.